### PR TITLE
CVE-2015-0235 GHOST: glibc gethostbyname buffer overflow

### DIFF
--- a/lib/facter/cve_2015_0235.rb
+++ b/lib/facter/cve_2015_0235.rb
@@ -1,0 +1,27 @@
+# http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-0235
+# GHOST
+#
+# Tests for an unpatched rpm of glibc
+# More https://access.redhat.com/articles/1332213
+
+glibc_nvr = Facter::Util::Resolution.exec('rpm -q --qf "%{name}-%{version}-%{release}.%{arch}\n" glibc').scan(/^(glibc-(\d+\.\d+).*)$/)
+
+if glibc_nvr.length
+  Facter.add('cve_2015_0235') do
+    require 'puppet'
+    rv = false
+    glibc_nvr.each do |glibc_rpm,glibc_version|
+      # fixed upstream version
+      if Puppet::Util::Package.versioncmp('2.18', glibc_version) > 0 then
+        # all RHEL updates include CVE in rpm changelog
+        if not system("rpm -q --changelog '#{glibc_rpm}' | grep -q 'CVE-2015-0235'") then
+          rv = true
+          break
+        end
+      end
+    end
+    setcode do
+      if rv then 'vulnerable' else 'not_vulnerable' end
+    end
+  end
+end


### PR DESCRIPTION
This is (currently) a fact that tests for CVE-2015-0235 on Red Hat systems based on the Red Hat Access Lab: [glibc (GHOST) Detector](https://access.redhat.com/labs/ghost/).
